### PR TITLE
preventDuplicateCall 오타 수정

### DIFF
--- a/action-player.js
+++ b/action-player.js
@@ -41,7 +41,7 @@ function Dispatcher() {
           /*
            작업을 실행하는 기본 순서는 병렬 실행이다.
            */
-          var preventDupliateCall = actionValue.preventDupliateCall || false;
+          var preventDupliateCall = actionValue.preventDuplicateCall || actionValue.preventDupliateCall || false;
           var sequenceProcessing = actionValue.sequence || false;
           var tasks = Array.isArray(actionValue.tasks) ? actionValue.tasks : [actionValue.tasks];
           var finish = typeof actionValue.finish === 'function' ? actionValue.finish : context[actionValue.finish];


### PR DESCRIPTION
기존에 액션 플레이어의 옵션에 `preventDupliateCall`라는 옵션이 있었습니다.
`preventDupliateCall`은 `preventDupli'c'ateCall`의 오타였습니다. 

사용하시는분들이 옵션에 오타가 나 있는지 모르시고,,,, 정확하게 사용을 하셔서 `preventDuplicateCall`이 동작하지 않는 경우가 발생해서, 수정해서 PR을 올립니다.

이미 작성되어 있는 코드도 정상적으로 동작하도록 작업했습니다. :) 